### PR TITLE
Find and fix a bug

### DIFF
--- a/src/core/portal.js
+++ b/src/core/portal.js
@@ -243,6 +243,8 @@ export function createModal(content, options = {}) {
 
   let portal;
   let backdropElement;
+  // BUG-S5-007 FIX: Declare backdropClickHandler in outer scope so close() can access it
+  let backdropClickHandler = null;
 
   // Create backdrop if needed
   if (backdrop) {
@@ -258,8 +260,6 @@ export function createModal(content, options = {}) {
       z-index: 9998;
     `;
 
-    // BUG-S5-007 FIX: Store backdrop click handler for cleanup
-    let backdropClickHandler = null;
     if (closeOnBackdrop) {
       backdropClickHandler = (e) => {
         if (e.target === backdropElement) {


### PR DESCRIPTION
The backdropClickHandler variable was declared inside the if(backdrop) block but referenced by the close() function outside that scope. This caused the event listener to never be properly removed when the modal was closed, leading to a memory leak.

Moved the variable declaration to the outer scope so close() can properly clean up the backdrop click listener.

Bug: BUG-S5-007 (Modal backdrop listener memory leak)